### PR TITLE
Make sales_price compatible with spree 2.1 and Rails 4.x

### DIFF
--- a/app/controllers/spree/admin/sale_prices_controller.rb
+++ b/app/controllers/spree/admin/sale_prices_controller.rb
@@ -30,7 +30,7 @@ module Spree
 
         # Load the product as a before filter. Redirect to the referer if no product is found
         def load_product
-          @product = Spree::Product.find_by_permalink(params[:product_id])
+          @product = Spree::Product.find_by(slug: params[:product_id])
           redirect_to request.referer unless @product.present?
         end
 

--- a/app/controllers/spree/home_controller_decorator.rb
+++ b/app/controllers/spree/home_controller_decorator.rb
@@ -3,7 +3,7 @@ module Spree
     def sale
       # TODO Refactor to include sales in searcher builder
       if params[:id]
-        @taxon = Spree::Taxon.find_by_permalink!(params[:id])
+        @taxon = Spree::Taxon.find_by!(slug: params[:id])
         @products = Spree::Product.in_sale.in_taxon(@taxon)
       else
         @products = Spree::Product.in_sale

--- a/spree_sales.gemspec
+++ b/spree_sales.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 2.1.4'
+  s.add_dependency 'spree_core', '~> 2.2.0'
 
   s.add_development_dependency 'capybara', '~> 2.1'
   s.add_development_dependency 'coffee-rails'


### PR DESCRIPTION
I've made the gem compatible with Rails 4 and Spree 2.2

Branch 2-1-stable may not be the best to pull-request against, but that is the branch that I took as base. 