### PR TITLE
Feature/icon

### DIFF
--- a/app/overrides/admin_decorator.rb
+++ b/app/overrides/admin_decorator.rb
@@ -1,5 +1,5 @@
 Deface::Override.new(virtual_path: "spree/admin/shared/_product_tabs",
                      name: "add_sale_prices_tab",
                      insert_bottom: "[data-hook='admin_product_tabs']",
-                     text: "<%= content_tag :li, :class => ('active' if current == Spree.t(:product_sale_prices)) do %><%= link_to_with_icon 'usd', Spree.t(:product_sale_prices), admin_product_sale_prices_path(@product) %><% end %>",
+                     partial: 'spree/admin/sale_prices/product_tab',
                      disabled: false)

--- a/app/views/spree/admin/sale_prices/_product_tab.html.erb
+++ b/app/views/spree/admin/sale_prices/_product_tab.html.erb
@@ -1,0 +1,3 @@
+<%= content_tag :li, :class => ('active' if current == Spree.t(:product_sale_prices)) do %>
+  <%= link_to_with_icon 'usd', Spree.t(:product_sale_prices), admin_product_sale_prices_path(@product) %>
+<% end %>


### PR DESCRIPTION
In the 3.0. branch the tab did not show up with a dollar icon. 

This fix cleans up the deface override a little, after wich it re-appeared. But regardless of the upgrade, this is a small improvement to clean up the deface overrides a little.