### PR TITLE
Feature/bump updated at

### DIFF
--- a/app/controllers/spree/admin/sale_prices_controller.rb
+++ b/app/controllers/spree/admin/sale_prices_controller.rb
@@ -21,6 +21,7 @@ module Spree
       def destroy
         sale_price = Spree::SalePrice.find(params[:id])
         sale_price.destroy
+        @product.touch
 
         respond_with(sale_price)
       end

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -24,6 +24,7 @@ Spree::Product.class_eval do
     all_variants = params[:all_variants] || true
 
     run_on_variants(all_variants) { |v| v.put_on_sale(value, params) }
+    touch
   end
   alias :create_sale :put_on_sale
 

--- a/spec/controllers/spree/admin/sale_prices_controller_spec.rb
+++ b/spec/controllers/spree/admin/sale_prices_controller_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Spree::Admin::SalePricesController, type: :controller do
+  routes { Spree::Core::Engine.routes }
+  let(:sale_price) { mock_model(Spree::SalePrice) }
+  let(:product) { mock_model(Spree::Product) }
+
+  before do
+    allow(Spree::Product).to receive(:find_by).and_return(product)
+  end
+
+  describe 'destroy format: js' do
+    before do
+      allow(Spree::SalePrice).to receive(:find).and_return(sale_price)
+    end
+
+    it 'finds the sale price by param' do
+      expect(Spree::SalePrice).to receive(:find).with('1337').and_return(sale_price)
+      delete :destroy, id: 1337, product_id: 42, format: :js
+    end
+
+    it 'deletes the sale price' do
+      expect(sale_price).to receive(:destroy)
+      delete :destroy, id: 1337, product_id: 42, format: :js
+    end
+  end
+end

--- a/spec/controllers/spree/admin/sale_prices_controller_spec.rb
+++ b/spec/controllers/spree/admin/sale_prices_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Spree::Admin::SalePricesController, type: :controller do
   routes { Spree::Core::Engine.routes }
   let(:sale_price) { mock_model(Spree::SalePrice) }
-  let(:product) { mock_model(Spree::Product) }
+  let(:product) { mock_model(Spree::Product, touch: nil) }
 
   before do
     allow(Spree::Product).to receive(:find_by).and_return(product)
@@ -21,6 +21,11 @@ describe Spree::Admin::SalePricesController, type: :controller do
 
     it 'deletes the sale price' do
       expect(sale_price).to receive(:destroy)
+      delete :destroy, id: 1337, product_id: 42, format: :js
+    end
+
+    it 'touches the product, effectively renewing the cache' do
+      expect(product).to receive(:touch)
       delete :destroy, id: 1337, product_id: 42, format: :js
     end
   end

--- a/spec/models/sale_price_spec.rb
+++ b/spec/models/sale_price_spec.rb
@@ -6,40 +6,48 @@ describe Spree::SalePrice do
   let(:sale_price) { create(:sale_price) }
 
   context "product#put_on_sale" do
-    before {
+    context "when put on sale" do
+      before {
+        product.put_on_sale(10, {start_at: 7.days.ago, end_at: 7.days.from_now})
+      }
+
+      it "should be active sale_price" do
+        expect(product.price.to_i).to be 10
+      end
+
+      it "product should be on sale" do
+        expect(product.on_sale?).to be true
+      end
+
+      it "product on sale should have an original price" do
+        expect(product.original_price.to_i).to be 50
+      end
+
+      it "product active sale should be an sale price class" do
+        expect(product.active_sale_in(Spree::Config[:currency]).class).to be Spree::SalePrice
+      end
+    end
+
+    it "touches the product, effectively updating the cache" do
+      expect(product).to receive(:touch)
       product.put_on_sale(10, {start_at: 7.days.ago, end_at: 7.days.from_now})
-    }
-
-    it "should be active sale_price" do
-      expect(product.price.to_i).to be 10
-    end
-
-    it "product should be on sale" do
-      expect(product.on_sale?).to be true
-    end
-
-    it "product on sale should have an original price" do
-      expect(product.original_price.to_i).to be 50
-    end
-
-    it "product active sale should be an sale price class" do
-      expect(product.active_sale_in(Spree::Config[:currency]).class).to be Spree::SalePrice
     end
   end
 
   context "variant#put_on_sale" do
-    before {
-      variant.put_on_sale(10, {start_at: 7.days.ago, end_at: 7.days.from_now})
-    }
+    context "when put on sale" do
+      before {
+        variant.put_on_sale(10, {start_at: 7.days.ago, end_at: 7.days.from_now})
+      }
 
-    it "variant should be on sale" do
-      expect(variant.on_sale?).to be true
+      it "variant should be on sale" do
+        expect(variant.on_sale?).to be true
+      end
+
+      it "variant product should be out of sale" do
+        expect(variant.product.on_sale?).to be false
+      end
     end
-
-    it "variant product should be out of sale" do
-      expect(variant.product.on_sale?).to be false
-    end
-
   end
 
   context "validations" do


### PR DESCRIPTION
One attempt to fix #12 Caching issues: bumping the updated_at.

It fixes the cases where an admin creates an active sale_price. But does not invalidate the cache once the sale-price becomes active or inactive after creating it.